### PR TITLE
[#145330113] Update machine configuration for Renos

### DIFF
--- a/conf/machine/at91sam9m10g45ek.conf
+++ b/conf/machine/at91sam9m10g45ek.conf
@@ -4,7 +4,7 @@
 
 require include/at91sam9.inc
 
-MACHINE_FEATURES = "kernel26 apm alsa ext2 ext3 usbhost usbgadget screen camera can touchscreen ppp"
+MACHINE_FEATURES = "kernel26 ext2 usbgadget vfat uboot "
 KERNEL_DEVICETREE = "at91sam9m10g45ek.dtb \
                      "
 


### PR DESCRIPTION
In the file `conf/machine/nedap9g45.conf`, the field `MACHINE_FEATURES`
was set to the same value that was also used for the `OE-classic`
implementation, except `alsa` (advanced linux sound architecture) which
was also not required and thus removed.