### PR TITLE
[#145998989] ubi: Add backwards compatibility for oe-classic u-boot  …

### DIFF
--- a/README
+++ b/README
@@ -1,9 +1,9 @@
-This layer provides support for Atmel | SMART microprocessors (aka AT91)
-========================================================================
+This layer provides support for Microchip microprocessors (aka AT91)
+====================================================================
 
-For more information about the Atmel | SMART product line see:
-http://www.atmel.com/products/microcontrollers/arm/
-Linux & Open Source on Atmel | SMART:
+For more information about the Microchip MPU product line see:
+http://www.microchip.com/design-centers/32-bit-mpus
+Linux & Open Source on Microchip microprocessors:
 http://www.linux4sam.org
 
 
@@ -164,8 +164,8 @@ for some useful guidelines to be followed when submitting patches:
 http://www.openembedded.org/wiki/How_to_submit_a_patch_to_OpenEmbedded
 
 Maintainers:
-Nicolas Ferre <nicolas.ferre@atmel.com>
-Patrice Vilchez <patrice.vilchez@atmel.com>
+Nicolas Ferre <nicolas.ferre@microchip.com>
+Patrice Vilchez <patrice.vilchez@microchip.com>
 
 When creating patches insert the [meta-atmel] tag in the subject, for example
 use something like:

--- a/conf/machine/at91sam9m10g45ek.conf
+++ b/conf/machine/at91sam9m10g45ek.conf
@@ -14,7 +14,8 @@ IMAGE_FSTYPES += " ubi tar.gz"
 MKUBIFS_ARGS = " -e 129024 -c 2047 -m 2048  -x lzo"
 UBINIZE_ARGS = " -m 2048 -p 128KiB -s 512"
 
-UBI_VOLNAME = "rootfs"
+# backwards compatibility...
+UBI_VOLNAME = "nedap9g45-rootfs"
 
 UBOOT_MACHINE = "${MACHINE}_nandflash_config"
 UBOOT_ENTRYPOINT = "0x70008000"

--- a/recipes-support/devmem2/devmem2.bb
+++ b/recipes-support/devmem2/devmem2.bb
@@ -1,0 +1,26 @@
+SUMMARY = "Simple program to read/write from/to any location in memory"
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://devmem2.c;endline=38;md5=a9eb9f3890384519f435aedf986297cf"
+PR = "r7"
+
+SRC_URI = "http://www.free-electrons.com/pub/mirror/devmem2.c;downloadfilename=devmem2-new.c \
+           file://devmem2-fixups-2.patch;apply=yes;striplevel=0"
+S = "${WORKDIR}"
+
+CFLAGS += "-DFORCE_STRICT_ALIGNMENT"
+
+python do_unpack_append() {
+    os.rename("devmem2-new.c", "devmem2.c")
+}
+
+do_compile() {
+    ${CC} -o devmem2 devmem2.c ${CFLAGS} ${LDFLAGS}
+}
+
+do_install() {
+    install -d ${D}${bindir}
+    install devmem2 ${D}${bindir}
+}
+
+SRC_URI[md5sum] = "e23f236e94be4c429aa1ceac0f01544b"
+SRC_URI[sha256sum] = "3b15515693bae1ebd14d914e46d388edfec2175829ea1576a7a0c8606ebbe639"

--- a/recipes-support/devmem2/devmem2/devmem2-fixups-2.patch
+++ b/recipes-support/devmem2/devmem2/devmem2-fixups-2.patch
@@ -1,0 +1,91 @@
+--- devmem2.c	2004-08-05 01:55:25.000000000 +0200
++++ devmem2_modif.c	2011-01-13 15:48:37.798799784 +0100
+@@ -45,12 +45,16 @@
+ #define MAP_SIZE 4096UL
+ #define MAP_MASK (MAP_SIZE - 1)
+ 
++static inline void *fixup_addr(void *addr, size_t size);
++
+ int main(int argc, char **argv) {
+     int fd;
+     void *map_base, *virt_addr; 
+-	unsigned long read_result, writeval;
++	unsigned long read_result, write_val;
+ 	off_t target;
+ 	int access_type = 'w';
++	char fmt_str[128];
++	size_t data_size;
+ 	
+ 	if(argc < 2) {
+ 		fprintf(stderr, "\nUsage:\t%s { address } [ type [ data ] ]\n"
+@@ -79,38 +83,51 @@
+     virt_addr = map_base + (target & MAP_MASK);
+     switch(access_type) {
+ 		case 'b':
++			data_size = sizeof(unsigned char);
++			virt_addr = fixup_addr(virt_addr, data_size);
+ 			read_result = *((unsigned char *) virt_addr);
+ 			break;
+ 		case 'h':
++			data_size = sizeof(unsigned short);
++			virt_addr = fixup_addr(virt_addr, data_size);
+ 			read_result = *((unsigned short *) virt_addr);
+ 			break;
+ 		case 'w':
++			data_size = sizeof(unsigned long);
++			virt_addr = fixup_addr(virt_addr, data_size);
+ 			read_result = *((unsigned long *) virt_addr);
+ 			break;
+ 		default:
+ 			fprintf(stderr, "Illegal data type '%c'.\n", access_type);
+ 			exit(2);
+ 	}
+-    printf("Value at address 0x%X (%p): 0x%X\n", target, virt_addr, read_result); 
++	sprintf(fmt_str, "Read at address  0x%%08lX (%%p): 0x%%0%dlX\n", 2*data_size);
++    printf(fmt_str, (unsigned long)target, virt_addr, read_result);
+     fflush(stdout);
+ 
+ 	if(argc > 3) {
+-		writeval = strtoul(argv[3], 0, 0);
++		write_val = strtoul(argv[3], 0, 0);
+ 		switch(access_type) {
+ 			case 'b':
+-				*((unsigned char *) virt_addr) = writeval;
++				virt_addr = fixup_addr(virt_addr, sizeof(unsigned char));
++				*((unsigned char *) virt_addr) = write_val;
+ 				read_result = *((unsigned char *) virt_addr);
+ 				break;
+ 			case 'h':
+-				*((unsigned short *) virt_addr) = writeval;
++				virt_addr = fixup_addr(virt_addr, sizeof(unsigned short));
++				*((unsigned short *) virt_addr) = write_val;
+ 				read_result = *((unsigned short *) virt_addr);
+ 				break;
+ 			case 'w':
+-				*((unsigned long *) virt_addr) = writeval;
++				virt_addr = fixup_addr(virt_addr, sizeof(unsigned long));
++				*((unsigned long *) virt_addr) = write_val;
+ 				read_result = *((unsigned long *) virt_addr);
+ 				break;
+ 		}
+-		printf("Written 0x%X; readback 0x%X\n", writeval, read_result); 
++		sprintf(fmt_str, "Write at address 0x%%08lX (%%p): 0x%%0%dlX, "
++			"readback 0x%%0%dlX\n",	2*data_size, 2*data_size);
++		printf(fmt_str, (unsigned long)target, virt_addr,
++			write_val, read_result);
+ 		fflush(stdout);
+ 	}
+ 	
+@@ -119,3 +136,12 @@
+     return 0;
+ }
+ 
++static inline void *fixup_addr(void *addr, size_t size)
++{
++#ifdef FORCE_STRICT_ALIGNMENT
++	unsigned long aligned_addr = (unsigned long)addr;
++	aligned_addr &= ~(size - 1);
++	addr = (void *)aligned_addr;
++#endif
++	return addr;
++}


### PR DESCRIPTION
The oe-classic u-boot version tries to mount a volume named 'nedap9g45-rootfs'. To be able to support a mixed setup (oe-classic u-boot and oe-core rootfs) the oe-core rootfs ubi volumename must match the name used in oe-classic.